### PR TITLE
raspberrypi5-64.coffee: Change slug to raspberrypi5

### DIFF
--- a/raspberrypi5-64.coffee
+++ b/raspberrypi5-64.coffee
@@ -3,8 +3,7 @@ deviceTypesCommon = require '@resin.io/device-types/common'
 
 module.exports =
 	version: 1
-	slug: 'raspberrypi5-64'
-	aliases: [ 'raspberrypi5-64' ]
+	slug: 'raspberrypi5'
 	name: 'Raspberry Pi 5'
 	arch: 'aarch64'
 	state: 'released'


### PR DESCRIPTION
We will only release 64 bits OS version so let's not suffix it with -64

Changelog-entry: Change Raspberry Pi 5 slug to raspberrypi5