### PR TITLE
balena-image-initramfs.bbappend: Increase rootfs maxsize to 40 MiB fo…

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,0 +1,1 @@
+IMAGE_ROOTFS_MAXSIZE:raspberrypi5 = "40960"


### PR DESCRIPTION
…r raspberrypi5

Build fails with:
ERROR: balena-image-initramfs-1.0-r0 do_image_cpio: The rootfs size 36864(K) exceeds IMAGE_ROOTFS_MAXSIZE: 32768(K)

Until we find out why this happens, let's increase it to unblock the build

Changelog-entry: Increase rootfs maxsize to 40 MiB for raspberrypi5