### PR TITLE
balena-image-initramfs.bbappend: Fix rpi5 machine name

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,1 +1,1 @@
-IMAGE_ROOTFS_MAXSIZE:raspberrypi5 = "40960"
+IMAGE_ROOTFS_MAXSIZE:raspberrypi5-64 = "40960"


### PR DESCRIPTION
Changelog-entry: Fix raspberrypi5 machine name in balena-image-initramfs.bbappend