### PR TITLE
rpi-config_git.bbappend: Use different config.txt for raspberrypi5-64

### DIFF
--- a/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/files/config.txt
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/files/config.txt
@@ -1,0 +1,83 @@
+# For more options and information see
+# http://rpf.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# uncomment if you get no picture on HDMI for a default "safe" mode
+#hdmi_safe=1
+
+# uncomment the following to adjust overscan. Use positive numbers if console
+# goes off screen, and negative if there is too much border
+#overscan_left=16
+#overscan_right=16
+#overscan_top=16
+#overscan_bottom=16
+
+# uncomment to force a console size. By default it will be display's size minus
+# overscan.
+#framebuffer_width=1280
+#framebuffer_height=720
+
+# uncomment if hdmi display is not detected and composite is being output
+#hdmi_force_hotplug=1
+
+# uncomment to force a specific HDMI mode (this will force VGA)
+#hdmi_group=1
+#hdmi_mode=1
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+#hdmi_drive=2
+
+# uncomment to increase signal to HDMI, if you have interference, blanking, or
+# no display
+#config_hdmi_boost=4
+
+# uncomment for composite PAL
+#sdtv_mode=2
+
+#uncomment to overclock the arm. 700 MHz is the default.
+#arm_freq=800
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+#dtparam=spi=on
+
+# Uncomment this to enable infrared communication.
+#dtoverlay=gpio-ir,gpio_pin=17
+#dtoverlay=gpio-ir-tx,gpio_pin=18
+
+# Additional overlays and parameters are documented /boot/overlays/README
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
+# Automatically load overlays for detected cameras
+camera_auto_detect=1
+
+# Automatically load overlays for detected DSI displays
+display_auto_detect=1
+
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+max_framebuffers=2
+
+# Run in 64-bit mode
+arm_64bit=1
+
+# Disable compensation for displays with overscan
+disable_overscan=1
+
+[cm4]
+# Enable host mode on the 2711 built-in XHCI USB controller.
+# This line should be removed if the legacy DWC2 controller is required
+# (e.g. for USB device mode) or if USB support is not required.
+otg_mode=1
+
+[all]
+
+[pi4]
+# Run as fast as firmware / board allows
+arm_boost=1
+
+[all]

--- a/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -1,3 +1,13 @@
+FILESEXTRAPATHS:append:raspberrypi5-64 := ":${THISDIR}/files"
+
+SRC_URI:append:raspberrypi5-64 = " \
+    file://config.txt \
+"
+
+do_deploy:append:raspberrypi5-64() {
+    cp ${WORKDIR}/config.txt ${DEPLOYDIR}/bootfiles/
+}
+
 do_deploy:append() {
     # Enable i2c by default
     echo "dtparam=i2c_arm=on" >>${DEPLOYDIR}/bootfiles/config.txt


### PR DESCRIPTION
Using the BSP supplied config.txt makes the board not boot, complains it cannot find the SD card device.
Suspicion is that the size of the config.txt file is the culprit but until we have more time to investigate let's just use the config.txt from Raspberry Pi OS.

Changelog-entry: Use different config.txt for raspberrypi5-64