### PR TITLE
Support Raspberry Pi AI kit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,7 @@
 	path = contracts
 	url = https://github.com/balena-io/contracts.git
 	branch = master
+[submodule "layers/meta-hailo"]
+	path = layers/meta-hailo
+	url = git@github.com:hailo-ai/meta-hailo.git
+	branch = kirkstone-v3.29.1

--- a/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample
+++ b/layers/meta-balena-raspberrypi/conf/samples/bblayers.conf.sample
@@ -18,4 +18,5 @@ BBLAYERS ?= " \
     ${TOPDIR}/../layers/meta-openembedded/meta-python \
     ${TOPDIR}/../layers/meta-openembedded/meta-perl \
     ${TOPDIR}/../layers/meta-raspberrypi \
+    ${TOPDIR}/../layers/meta-hailo/meta-hailo-accelerator \
     "

--- a/layers/meta-balena-raspberrypi/recipes-core/extra-udev-rules/extra-udev-rules.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/extra-udev-rules/extra-udev-rules.bbappend
@@ -2,9 +2,15 @@ FILESEXTRAPATHS:append := ":${THISDIR}/files"
 
 SRC_URI:append = " \
 	file://86-nm-unmanaged-fin.rules \
+	file://51-hailo-udev.rules \
 	"
 
 do_install:append:fincm3() {
 	# Install balenaFin uAP interface rules
 	install -D -m 0644 ${WORKDIR}/86-nm-unmanaged-fin.rules ${D}/lib/udev/rules.d/86-nm-unmanaged-fin.rules
+}
+
+do_install:append:raspberrypi5-64() {
+	# Install hailo AI accelerator rules
+	install -D -m 0644 ${WORKDIR}/51-hailo-udev.rules ${D}/lib/udev/rules.d/51-hailo-udev.rules
 }

--- a/layers/meta-balena-raspberrypi/recipes-core/extra-udev-rules/files/51-hailo-udev.rules
+++ b/layers/meta-balena-raspberrypi/recipes-core/extra-udev-rules/files/51-hailo-udev.rules
@@ -1,0 +1,2 @@
+#Change mode rules for Hailo's PCIe driver if RPI AI kit is installed
+SUBSYSTEM=="hailo_chardev", MODE="0666"

--- a/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-raspberrypi/recipes-core/images/balena-image.bbappend
@@ -92,3 +92,8 @@ IMAGE_INSTALL:append:raspberrypi4-superhub = " \
     phoenix-peripheral-gpio-wdt \
     phoenix-peripheral-rtc-sync \
 "
+
+IMAGE_INSTALL:append:raspberrypi5-64 = " \
+    hailo-firmware \
+    hailo-pci \
+"


### PR DESCRIPTION
This PR adds support for the [hailo AI accelerator drivers](https://github.com/hailo-ai/hailort-drivers) using [meta-hailo-accelerator layer ](https://github.com/hailo-ai/meta-hailo/tree/kirkstone-v3.26.1/meta-hailo-accelerator) which enables the use of the [Raspberry Pi AI kit](https://www.raspberrypi.com/documentation/accessories/ai-kit.html).

This only installs:
- hailo-firmware: v4.18.1
- hailo-pcie driver: v4.18.1 
- udev rules

**NOTE:** It doesn't include any of the other tools like `hailort` or `hailortcli`

Output of `dmesg`:
```
root@3759029:~# dmesg | grep hailo
[   19.531860] hailo_pci: loading out-of-tree module taints kernel.
[   19.534265] hailo: Init module. driver version 4.18.1
[   19.535375] hailo 0000:01:00.0: Probing on: 1e60:2864...
[   19.535380] hailo 0000:01:00.0: Probing: Allocate memory for device extension, 11632
[   19.535395] hailo 0000:01:00.0: enabling device (0000 -> 0002)
[   19.535400] hailo 0000:01:00.0: Probing: Device enabled
[   19.535410] hailo 0000:01:00.0: Probing: mapped bar 0 - 000000009792eaf5 16384
[   19.535414] hailo 0000:01:00.0: Probing: mapped bar 2 - 000000002b756677 4096
[   19.535417] hailo 0000:01:00.0: Probing: mapped bar 4 - 00000000442d39d3 16384
[   19.535421] hailo 0000:01:00.0: Probing: Setting max_desc_page_size to 4096, (page_size=4096)
[   19.535428] hailo 0000:01:00.0: Probing: Enabled 64 bit dma
[   19.535430] hailo 0000:01:00.0: Probing: Using userspace allocated vdma buffers
[   19.535433] hailo 0000:01:00.0: Disabling ASPM L0s 
[   19.535436] hailo 0000:01:00.0: Successfully disabled ASPM L0s 
[   19.728577] hailo 0000:01:00.0: Firmware was loaded successfully
[   19.741504] hailo 0000:01:00.0: Probing: Added board 1e60-2864, /dev/hailo0
```